### PR TITLE
HMR Support

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -2,7 +2,7 @@
   "name": "squint-demo",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "vite -d",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/index.mjs
+++ b/index.mjs
@@ -1,21 +1,45 @@
 import { compileString } from "squint-cljs";
-import esbuild from "esbuild";
+import path, { dirname } from "path";
+import fs from "fs";
 
-// TODO: squint source mapping
 export default function viteSquint(opts = {}) {
   const squint = {
     name: "squint_compile",
-    transform: function (code, id) {
+    enforce: "pre",
+    async load(id) {
+      // the resolveId adds the .jsx extension
+      if (/\.cljs.jsx$/.test(id)) {
+        // for cljs files, we just need to load and compile
+        // TODO: macros
+        // TODO: squint source mapping
+        const file = id.replace(/.jsx$/, "");
+        const code = await fs.promises.readFile(file, "utf-8");
+        const compiled = compileString(code);
+        return { code: compiled, map: null };
+      }
+    },
+    resolveId(id, imported) {
       if (/\.cljs$/.test(id)) {
-        const cs = compileString(code);
-        const jsx = esbuild.transformSync(cs, {
-          loader: "jsx",
-          jsx: "automatic",
-        });
-        return {
-          code: jsx.code,
-          map: null,
-        };
+        // For cljs files we need to do the following:
+        // absolutize the path, this makes it easier for load and other plugins
+        // append .jsx so that other plugins can pick it up
+        const absolutePath = path.resolve(dirname(imported), id);
+        return absolutePath + ".jsx";
+      }
+    },
+    handleHotUpdate({file, server, modules }) {
+      if (/\.cljs$/.test(file)) {
+        // this needs to be the same id returned by resolveId this is what
+        // vite uses as the modules identifier
+        const resolveId = file + ".jsx";
+        const module = server.moduleGraph.getModuleById(resolveId);
+        if (module) {
+          // invalidate dependants
+          server.moduleGraph.onFileChange(resolveId);
+          // hot reload
+          return [...modules, module ]
+        }
+        return modules;
       }
     },
   };

--- a/index.mjs
+++ b/index.mjs
@@ -18,12 +18,16 @@ export default function viteSquint(opts = {}) {
         return { code: compiled, map: null };
       }
     },
-    resolveId(id, imported) {
+    resolveId(id, imported, options) {
       if (/\.cljs$/.test(id)) {
         // For cljs files we need to do the following:
         // absolutize the path, this makes it easier for load and other plugins
         // append .jsx so that other plugins can pick it up
         const absolutePath = path.resolve(dirname(imported), id);
+        if (options.scan) {
+          // this is a scan, return virtual module
+          return "\0" + absolutePath + ".jsx";
+        }
         return absolutePath + ".jsx";
       }
     },

--- a/index.mjs
+++ b/index.mjs
@@ -25,7 +25,14 @@ export default function viteSquint(opts = {}) {
         // append .jsx so that other plugins can pick it up
         const absolutePath = path.resolve(dirname(imported), id);
         if (options.scan) {
-          // this is a scan, return virtual module
+          // Vite supports the concept of virtual modules, which are not direct
+          // files on disk but dynamically generated contents that Vite and its
+          // plugins can work with. We return a virtual module identifier
+          // (prefixed with \0 to denote its virtual nature), we effectively
+          // communicate to Vite and other plugins in the ecosystem that the
+          // module is managed by the plugin and should be treated differently
+          // from regular file-based modules. As `.cljs.jsx` files are not real.
+          // https://vitejs.dev/guide/api-plugin#virtual-modules-convention
           return "\0" + absolutePath + ".jsx";
         }
         return absolutePath + ".jsx";


### PR DESCRIPTION
This fixes the issues I was mentioning in #11 we were taking over the esbuild and trying to convert all the jsx. This should be left to the other plugins. All we do now is compile squint into JS and leave the other plugins to do their jobs. This also fixes HMR.

cc @martinklepsch 